### PR TITLE
Refact functions from storage to a class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { App } from '@slack/bolt';
-import { setValue } from './storage';
+import { storage } from './storage';
 import Twitter from 'twitter';
 import { returnValue } from './messages/messages';
 
@@ -20,7 +20,7 @@ app.message(/^:.*[^:]$/, async ({ context, say }) => {
     try {
         const command = context.matches[0].toLowerCase();
         await say(`getting ${command}`);
-        await say(await returnValue(command));
+        await say(await returnValue(command, storage));
     } catch (error) {
         await say('command failed');
         app.error(error);
@@ -35,7 +35,7 @@ app.command('/create', async ({ command, ack, say }) => {
         if (args) {
             const [, commandName, values] = args; // ignoring full match (first element)
             const value = values.includes(' ') ? values.split(' ') : values;
-            await setValue(`:${commandName}`.toLowerCase(), value);
+            await storage.setValue(`:${commandName}`.toLowerCase(), value);
             await say(`You can now use the command writing :${commandName}`);
         } else {
             await say('Invalid command pattern');

--- a/src/messages/messages.ts
+++ b/src/messages/messages.ts
@@ -1,42 +1,47 @@
 import { getRandomElement, isUrl } from '../utils';
-import { getValue } from '../storage';
+import { Storage } from '../storage';
 
-export async function returnValue(command: string): Promise<string | {
-    text: string;
-    blocks: {
-        type: string;
-        title: {
-            type: string;
-            text: any;
-        };
-        block_id: string;
-        image_url: string;
-        alt_text: string;
-    }[];
-}>{
-    const response = await getValue(command);
-    if (response) { 
-        const selectedResponse = response instanceof Array? getRandomElement(response) : response;
+type SlackReturn =
+    | string
+    | {
+          text: string;
+          blocks: {
+              type: string;
+              title: {
+                  type: string;
+                  text: any;
+              };
+              block_id: string;
+              image_url: string;
+              alt_text: string;
+          }[];
+      };
 
-        if (isUrl(selectedResponse)){
+export async function returnValue(command: string, storage: Storage): Promise<SlackReturn> {
+    const response = await storage.getValue(command);
+    if (response) {
+        const selectedResponse = response instanceof Array ? getRandomElement(response) : response;
+
+        if (isUrl(selectedResponse)) {
             return {
                 text: selectedResponse,
-                blocks: [{
-                    type: 'image',
-                    title: {
-                        type: 'plain_text',
-                        text: command
+                blocks: [
+                    {
+                        type: 'image',
+                        title: {
+                            type: 'plain_text',
+                            text: command,
+                        },
+                        block_id: 'orange_image',
+                        image_url: selectedResponse,
+                        alt_text: 'piece of shit',
                     },
-                    block_id: 'orange_image',
-                    image_url: selectedResponse,
-                    alt_text: 'piece of shit'
-                }]
+                ],
             };
         } else {
             return selectedResponse;
         }
-    }
-    else { 
+    } else {
         return "command doesn't exist";
     }
 }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,34 +1,44 @@
-import redis, { ClientOpts } from 'redis';
+import redis, { ClientOpts, RedisClient } from 'redis';
 
 const PORT = Number(process.env.REDIS_PORT) || 3333;
 const redisUrl = process.env.REDIS_URL || '';
-const configClient: ClientOpts= {
+const configClient: ClientOpts = {
     auth_pass: process.env.REDIS_PASSWORD,
 };
 
-const client = redis.createClient(PORT, redisUrl, configClient);
+type ReturnTypeRedis = string | string[] | null;
 
-type ReturnTypeRedis = string | string[] | null
-
-export async function getValue(key: string): Promise<ReturnTypeRedis> {
-    const promiseRedis = new Promise<ReturnTypeRedis>((resolve, reject) => {
-        client.get(key, (error, reply) => {
-            if (error) {
-                reject(error);
-            }
-            resolve(JSON.parse(reply ?? JSON.stringify(null)));
-        });
-    });
-    return promiseRedis;
+export interface Storage {
+    getValue: (key: string) => Promise<ReturnTypeRedis>;
+    setValue: (key: string, value: string | string[]) => Promise<void>;
 }
 
-export async function setValue(key: string, value: string | string[]): Promise<void> {
-    const promiseRedis = new Promise<void>((resolve, reject) => {
-        client.set(key, JSON.stringify(value), (error) => {
-            if (error) reject(error);
-            resolve();
+class StorageImplementation implements Storage {
+    constructor(private client: RedisClient) {}
+
+    async setValue(key: string, value: string | string[]): Promise<void> {
+        const promiseRedis = new Promise<void>((resolve, reject) => {
+            this.client.set(key, JSON.stringify(value), (error) => {
+                if (error) reject(error);
+                resolve();
+            });
         });
-    });
-    return promiseRedis;
+        return promiseRedis;
+    }
+
+    async getValue(key: string): Promise<ReturnTypeRedis> {
+        const promiseRedis = new Promise<ReturnTypeRedis>((resolve, reject) => {
+            this.client.get(key, (error, reply) => {
+                if (error) {
+                    reject(error);
+                }
+                resolve(JSON.parse(reply ?? JSON.stringify(null)));
+            });
+        });
+        return promiseRedis;
+    }
 }
 
+const redisClient = redis.createClient(PORT, redisUrl, configClient);
+
+export const storage = new StorageImplementation(redisClient);


### PR DESCRIPTION
With this implementation, all functions that depend on storage should explicitly declare on its arguments that it needs the storage. It will become easier to identify what is using storage just by looking at `index.ts`.